### PR TITLE
En attendant PyConFr 2021-04: peertube & direct links

### DIFF
--- a/en-attendant-pyconfr-2020-2021/videos/bash-trucs-astuces-mdk.json
+++ b/en-attendant-pyconfr-2020-2021/videos/bash-trucs-astuces-mdk.json
@@ -18,6 +18,15 @@
     {
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=GJsdFHcVT3g"
+    },
+    {
+      "size": 40664479,
+      "type": "mp4",
+      "url": "https://dl.afpy.org/en-attendant-la-pycon-fr-2020-2021/2021-04%20Bash%20-%20trucs%20&%20astuces%20-%20mdk.mp4"
+    },
+    {
+      "type": "peertube",
+      "url": "https://bittube.video/videos/watch/bc21c871-50a8-4002-bb00-0d57ad607527"
     }
   ]
 }

--- a/en-attendant-pyconfr-2020-2021/videos/enums-jeffd.json
+++ b/en-attendant-pyconfr-2020-2021/videos/enums-jeffd.json
@@ -18,6 +18,15 @@
     {
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=ux3kryAFC7o"
+    },
+    {
+      "size": 35351294,
+      "type": "mp4",
+      "url": "https://dl.afpy.org/en-attendant-la-pycon-fr-2020-2021/2021-04%20Les%20Enums%20-%20Jeffd.mp4"
+    },
+    {
+      "type": "peertube",
+      "url": "https://bittube.video/videos/watch/1e29c821-e4f0-44ed-8dda-64c549cc85fe"
     }
   ]
 }

--- a/en-attendant-pyconfr-2020-2021/videos/parallelisme-cgifl300.json
+++ b/en-attendant-pyconfr-2020-2021/videos/parallelisme-cgifl300.json
@@ -18,6 +18,15 @@
     {
       "type": "youtube",
       "url": "https://www.youtube.com/watch?v=O3VAIc4Lhxo"
+    },
+    {
+      "size": 21137219,
+      "type": "mp4",
+      "url": "https://dl.afpy.org/en-attendant-la-pycon-fr-2020-2021/2021-04%20Parall%C3%A9lisme%20-%20cGIfl300.mp4"
+    },
+    {
+      "type": "peertube",
+      "url": "https://bittube.video/videos/watch/39a5f136-03a7-4bde-882e-57f857fe3228"
     }
   ]
 }


### PR DESCRIPTION
En attendant PyConFr 2021-04: add [peertube](https://bittube.video/video-channels/en_attendant_la_pyconfr_2020_2021/videos) and [direct links](https://dl.afpy.org/en-attendant-la-pycon-fr-2020-2021/).